### PR TITLE
Fix for basePath appending logic to fix Issue #1660

### DIFF
--- a/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java
@@ -94,8 +94,21 @@ public final class AppiumDriverLocalService extends DriverService {
     }
 
     public AppiumDriverLocalService withBasePath(String basePath) {
-        this.basePath = basePath;
+        this.basePath = sanitizeBasePath(basePath);
         return this;
+    }
+
+    @SneakyThrows private static String sanitizeBasePath(String basePath) {
+        if (null == basePath) {
+            LOG.warn("Base Path cannot be NULL -- ignoring the basepath configuration");
+            return null;
+        }
+        basePath = basePath.trim();
+        if (basePath.isBlank() || basePath.isEmpty()) {
+            LOG.warn("Base Path cannot be Empty or Blank -- ignoring the basepath configuration");
+            return null;
+        }
+        return (basePath.endsWith("/") ? basePath : basePath + "/");
     }
 
     public String getBasePath() {

--- a/src/test/java/io/appium/java_client/service/local/ServerBuilderTest.java
+++ b/src/test/java/io/appium/java_client/service/local/ServerBuilderTest.java
@@ -6,6 +6,7 @@ import static io.appium.java_client.service.local.AppiumDriverLocalService.build
 import static io.appium.java_client.service.local.AppiumServiceBuilder.APPIUM_PATH;
 import static io.appium.java_client.service.local.flags.GeneralServerFlag.CALLBACK_ADDRESS;
 import static io.appium.java_client.service.local.flags.GeneralServerFlag.SESSION_OVERRIDE;
+import static io.appium.java_client.service.local.flags.GeneralServerFlag.BASEPATH;
 import static io.github.bonigarcia.wdm.WebDriverManager.chromedriver;
 import static java.lang.System.getProperty;
 import static java.lang.System.setProperty;
@@ -311,5 +312,12 @@ public class ServerBuilderTest {
                 .build();
         service.start();
         assertTrue(testLogFile.exists());
+    }
+
+    @Test
+    public void checkAbilityToStartServiceUsingBasePath() {
+        service = new AppiumServiceBuilder().withArgument(BASEPATH, "/wd/hub").build();
+        service.start();
+        assertTrue(service.isRunning());
     }
 }


### PR DESCRIPTION
## Change list

Fixed the logic of appending basepath to the Hub URL which fixes Issue #1660 - https://github.com/appium/java-client/issues/1660.

AppiumDriverLocalService was not able to start with Appium CLI versions < 2 as the ping() method was not able to get the status URL properly. Fixed the logic of appending basepath to sanitise the user input and appending basepath with "/" in the end, if not provided by user.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ x ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Test Execution logs - https://gist.github.com/robinGupta11392/e8c37c7e10e03cd00a4d44d398402738
Issue fixed - https://github.com/appium/java-client/issues/1660
Changed Classes:
 - ServerBuilderTest
 - AppiumDriverLocalService
 
Method Added:
 - sanitizeBasePath
 
Method Modified:
 - withBasePath

Test Added:
 - checkAbilityToStartServiceUsingBasePath